### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ For example, the snippet below uses grep to filter tests by name and only runs o
 mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 ```
 
-### Changing the Test Tag
-These test suites use tags to identify which implementation's endpoints are used in tests.
-If you need to change the tag the suites will run on you can change it in `./config/runner.json`.
-
 ### Testing Locally
 If you want to test implementations or just endpoints running locally, you can
 copy `localImplementationsConfig.example.cjs` to `.localImplementationsConfig.cjs`
@@ -136,20 +132,6 @@ passed as environment variables to the test script. To see which implementations
 secrets, please check the implementation manifest within the
 [vc-test-suite-implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main/implementations) library.
 
-## Docker Integration (TODO)
-
-We are presently working on implementing a new feature that will enable the
-use of Docker images instead of live endpoints. The Docker image that
-you provide will be started when the test suite is run. The image is expected
-to expose the API provided above, which will be used in the same way that
-live HTTP endpoints are used above.
-
-## Contribute
-
-See [the CONTRIBUTING.md file](CONTRIBUTING.md).
-
-Pull Requests are welcome!
-
 ## License
 
-See [the LICENSE.md file](LICENSE.md)
+[BSD-3-Clause](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -127,11 +127,7 @@ For instance, if your `.localImplementationsConfig.cjs` config file looks like
 the config above, you can adjust the tag used in each test suite by modifying `./config/runner.json`
 to filter the implementations by `localhost` and other tags.
 
-## Implementation
-
-You will need an issuer and verifier that are compatible with [VC API](https://w3c-ccg.github.io/vc-api/)
-and are capable of handling issuance and verification of Verifiable Credentials
-with `DataIntegrityProof` proof type using the `eddsa-rdfc-2022` or `eddsa-jcs-2022` cryptosuites.
+## Adding a Public Implementation
 
 To add your implementation to this test suite, you will need to add 2 endpoints
 to your implementation manifest.
@@ -143,7 +139,7 @@ All endpoints will need the tags either `eddsa-rdfc-2022` or `eddsa-jcs-2022`.
 
 A simplified manifest would look like this:
 
-```js
+```json
 {
   "name": "My Company",
   "implementation": "My implementation",
@@ -169,12 +165,12 @@ A simplified manifest would look like this:
 
 The example above represents an unauthenticated endpoint. You may add ZCAP or
 OAuth2 authentication to your endpoints. You can find an example in the
-[vc-test-suite-implementations README](https://github.com/w3c/vc-test-suite-implementations#adding-a-new-implementation).
+[w3c/vc-test-suite-implementations README](https://github.com/w3c/vc-test-suite-implementations#adding-a-new-implementation).
 
 To run the tests, some implementations may require client secrets that can be
 passed as environment variables to the test script. To see which implementations require client
 secrets, please check the implementation manifest within the
-[vc-test-suite-implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main/implementations) library.
+[w3c/vc-test-suite-implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main/implementations) repo.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
 # [EdDSA](https://www.w3.org/TR/vc-di-eddsa/) Cryptosuite test suite
 
-## Table of Contents
-
-- [EdDSA Cryptosuite test suite](#eddsa-cryptosuite-test-suite)
-  - [Table of Contents](#table-of-contents)
-  - [Background](#background)
-  - [Install](#install)
-  - [Usage](#usage)
-    - [Running Specific Tests](#Running-Specific-Tests)
-    - [Changing the Test Tag](#Changing-the-test-tag)
-    - [Testing Locally](#testing-locally)
-  - [Implementation](#implementation)
-  - [Docker Integration (TODO)](#docker-integration-todo)
-  - [Contribute](#contribute)
-  - [License](#license)
-
-## Background
-Provides interoperability tests for verifiable credential processors
-(issuers and verifiers) that support [EdDSA](https://www.w3.org/TR/vc-di-eddsa/)
+Provides interoperability tests for Verifiable Credential processors
+(Issuers and Verifiers) that support [EdDSA](https://www.w3.org/TR/vc-di-eddsa/)
 and [Data Integrity](https://www.w3.org/TR/vc-data-integrity/) cryptosuites.
+
+- [Install](#install)
+- [Usage](#usage)
+  - [Running Specific Tests](#Running-Specific-Tests)
+  - [Changing the Test Tag](#Changing-the-test-tag)
+  - [Testing Locally](#testing-locally)
+- [Implementation](#implementation)
+- [Contribute](#contribute)
+- [License](#license)
+
 
 ## Install
 
@@ -32,7 +26,7 @@ To generate test data for `eddsa-jcs-2022` tests, testers can specify the
 issuer name using the environment variable `ISSUER_NAME_JCS`.
 
 If `$ISSUER_NAME_JCS` is not specified, `bovine` will be used.
-```
+```sh
 ISSUER_NAME_JCS="IssuerNameJCS"  npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,22 +65,25 @@ Content-Type: application/ld+json
     "https://www.w3.org/ns/credentials/v2",
     "https://w3id.org/security/data-integrity/v2"
   ],
-  "credential": {},
-  "options": {}
+  "verifiableCredential": {
+    "proof": {}
+  }
 }
 ```
 
 ```http
 POST /credentials/derive
-```
+Content-Type: application/ld+json
 
-### Running Specific Tests
-This suite uses [mocha.js](https://mochajs.org) as the test runner.
-Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.
-
-For example, the snippet below uses grep to filter tests by name and only runs one of the test suites.
-```bash
-mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "verifiableCredential": {
+    "proof": {}
+  }
+}
 ```
 
 ### Testing Locally
@@ -126,6 +129,15 @@ filter implementations based on a specific tag in your local configuration file.
 For instance, if your `.localImplementationsConfig.cjs` config file looks like
 the config above, you can adjust the tag used in each test suite by modifying `./config/runner.json`
 to filter the implementations by `localhost` and other tags.
+
+### Running Specific Tests
+This suite uses [mocha.js](https://mochajs.org) as the test runner.
+Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.
+
+For example, the snippet below uses grep to filter tests by name and only runs one of the test suites.
+```bash
+mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
+```
 
 ## Adding a Public Implementation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,50 @@ If `$ISSUER_NAME_JCS` is not specified, `bovine` will be used.
 ISSUER_NAME_JCS="IssuerNameJCS"  npm test
 ```
 
+### Wrapping Your Implementation
+
+A simplified version of issuer and verifier endpoints from
+[VC API](https://w3c-ccg.github.io/vc-api/)
+are used by the test suite code to communicate with the underlying cryptosuite.
+The credentials MUST use the `DataIntegrityProof` proof type and implement the
+`eddsa-rdfc-2022` and/or `eddsa-jcs-2022` cryptosuites.
+
+A community example implementation (written in Node.js/Express) is available at
+https://github.com/Wind4Greg/Server-for-VCs
+
+The typical server will implement the following endpoints and methods:
+```http
+POST /credentials/issue
+Content-Type: application/ld+json
+
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "credential": {},
+  "options": {}
+}
+```
+
+```http
+POST /credentials/verify
+Content-Type: application/ld+json
+
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "credential": {},
+  "options": {}
+}
+```
+
+```http
+POST /credentials/derive
+```
+
 ### Running Specific Tests
 This suite uses [mocha.js](https://mochajs.org) as the test runner.
 Mocha has [multiple options](https://mochajs.org/#command-line-usage) for filtering which tests run.

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ mocha --grep '"specificProperty" test name' ./tests/10-specific-test-suite.js
 
 ## Adding a Public Implementation
 
-To add your implementation to this test suite, you will need to add 2 endpoints
-to your implementation manifest.
-- A credential issuer endpoint (/credentials/issue) in the `issuers` property.
-- A credential verifier endpoint (/credentials/verify) in the `verifiers`
+To [add your implementation to the public list of tested implementations](https://github.com/w3c/vc-test-suite-implementations/tree/main?tab=readme-ov-file#adding-a-new-implementation),
+you will need to add 2 endpoints to your implementation manifest:
+- A credential issuer endpoint (ex: `/credentials/issue`) in the `issuers` property.
+- A credential verifier endpoint (ex: `/credentials/verify`) in the `verifiers`
   property.
 
 All endpoints will need the tags either `eddsa-rdfc-2022` or `eddsa-jcs-2022`.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ and [Data Integrity](https://www.w3.org/TR/vc-data-integrity/) cryptosuites.
 
 - [Install](#install)
 - [Usage](#usage)
-  - [Running Specific Tests](#Running-Specific-Tests)
-  - [Changing the Test Tag](#Changing-the-test-tag)
-  - [Testing Locally](#testing-locally)
-- [Implementation](#implementation)
-- [Contribute](#contribute)
+    - [Wrapping Your Implementation](#wrapping-your-implementation)
+    - [Testing Locally](#testing-locally)
+    - [Running Specific Tests](#running-specific-tests)
+- [Adding a Public Implementation](#adding-a-public-implementation)
 - [License](#license)
-
 
 ## Install
 


### PR DESCRIPTION
- Improve README intro.
- Remove tag changing, Docker, & contributing.
- Describe wrapping HTTP API a bit.
- Improve language/links around implementations.
- Move Running Specifict Tests section down.
- Clarify how to setup public implementations.
