### PR TITLE
Add cryptosuiteName to eddsa-rdfc-2022 ops.

### DIFF
--- a/tests/05-di-rdfc-create.js
+++ b/tests/05-di-rdfc-create.js
@@ -17,5 +17,6 @@ const {match} = endpoints.filterByTag({
 
 checkDataIntegrityProofFormat({
   implemented: match,
-  testDescription: 'Data Integrity (eddsa-rdfc-2022 issuers)'
+  testDescription: 'Data Integrity (eddsa-rdfc-2022 issuers)',
+  cryptosuiteName: 'eddsa-rdfc-2022'
 });


### PR DESCRIPTION
Adds 2 DI tests by passing the `cryptosuiteName` to the di test suite assertion.