### PR TITLE
Turn on proofChain tests for eddsa-rdfc-2022.

### DIFF
--- a/tests/15-di-rdfc-verify.js
+++ b/tests/15-di-rdfc-verify.js
@@ -25,9 +25,13 @@ const testDataOptions = {
   cryptosuite: eddsaRdfc2022CryptoSuite,
   key
 };
+const optionalTests = {
+  proofChain: true
+};
 
 checkDataIntegrityProofVerifyErrors({
   implemented: match,
   testDescription: 'Data Integrity (eddsa-rdfc-2022 verifiers)',
-  testDataOptions
+  testDataOptions,
+  optionalTests
 });


### PR DESCRIPTION
Awaits verifier proofChain tests in data integrity test suite assertion:

https://github.com/w3c-ccg/data-integrity-test-suite-assertion/pull/110