### PR TITLE
DO NOT THROW IN BEFORE BLOCKS.

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -31,9 +31,9 @@ export const createInitialVc = async ({issuer, vc}) => {
   const body = {credential, options};
   const {data, error} = await issuer.post({json: body});
   if(error) {
-    console.warn(
-      `Issuance failed for ${issuer.settings.endpoint}`,
-      {error, body});
+    console.warn(`Issuance failed for ${issuer.settings.endpoint}`);
+    console.error(error);
+    console.log(JSON.stringify({body}, null, 2));
   }
   return data;
 };

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -31,7 +31,9 @@ export const createInitialVc = async ({issuer, vc}) => {
   const body = {credential, options};
   const {data, error} = await issuer.post({json: body});
   if(error) {
-    throw error;
+    console.warn(
+      `Issuance failed for ${issuer.settings.endpoint}`,
+      {error, body});
   }
   return data;
 };


### PR DESCRIPTION
Changes suite to behave more like ecdsa. When log errors in before blocks instead of throwing.